### PR TITLE
Add postgresql test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,9 @@ jobs:
         if: ${{ matrix.php-versions == '7.4' || matrix.php-versions == '8.0' }}
       - name: Run PHPUnit
         run: vendor/bin/phpunit --colors=always --config phpunit.xml.dist
+        env:
+          MYSQL_DB_HOST: 127.0.0.1
+
   coverage:
     name: Tests coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         php-versions:
           - '8.3'
           - '8.4'
+
     services:
       mysql:
         image: "mysql:${{ matrix.db-version }}"
@@ -43,7 +44,7 @@ jobs:
         options: >-
           --health-cmd="mysqladmin ping --silent"
         ports:
-          - '3406:3306'
+          - '3306:3306'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,8 +79,12 @@ jobs:
         with:
           dependency-versions: locked
           composer-options: --no-ansi --no-interaction --no-progress
+
       - name: Run PHPUnit with coverage
         run: vendor/bin/phpunit --testsuite=unit --colors=always --coverage-clover=clover.xml
+        env:
+          MYSQL_DB_HOST: 127.0.0.1
+
       - name: Upload coverage
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/pg.yml
+++ b/.github/workflows/pg.yml
@@ -1,0 +1,53 @@
+name: pg
+
+on: [push]
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system:
+          - ubuntu-latest
+        db-version:
+          - '13'
+        php-versions:
+          - '8.3'
+          - '8.4'
+
+    services:
+      postgres:
+        image: "postgres:${{ matrix.db-version }}"
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: pdo_pgsql, libxml, dom
+          coverage: none
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          dependency-versions: locked
+          composer-options: --no-ansi --no-interaction --no-progress
+
+      - name: Override config
+        run: cp ci/phpunit/phpunit.96.xml phpunit.xml.dist
+        if: ${{ matrix.php-versions == '7.4' || matrix.php-versions == '8.0' }}
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --colors=always --config phpunit.xml.dist
+        env:
+          POSTGRES_DB_HOST: 127.0.0.1

--- a/.github/workflows/pg.yml
+++ b/.github/workflows/pg.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_DB: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5

--- a/Dockerfile.php8.3
+++ b/Dockerfile.php8.3
@@ -2,9 +2,9 @@ FROM php:8.3-cli
 
 RUN apt-get update \
   && apt-get -y install --no-install-recommends \
-    git unzip
+    git unzip libpq-dev
 
-RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install pdo_mysql pgsql pdo_pgsql
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 

--- a/Dockerfile.php8.3
+++ b/Dockerfile.php8.3
@@ -4,6 +4,8 @@ RUN apt-get update \
   && apt-get -y install --no-install-recommends \
     git unzip
 
+RUN docker-php-ext-install pdo_mysql
+
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 WORKDIR /usr/src/myapp

--- a/Dockerfile.php8.4
+++ b/Dockerfile.php8.4
@@ -1,0 +1,13 @@
+FROM php:8.4-cli
+
+RUN apt-get update \
+  && apt-get -y install --no-install-recommends \
+    git unzip
+    
+RUN docker-php-ext-install pdo_mysql
+
+
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+WORKDIR /usr/src/myapp

--- a/Dockerfile.php8.4
+++ b/Dockerfile.php8.4
@@ -2,11 +2,9 @@ FROM php:8.4-cli
 
 RUN apt-get update \
   && apt-get -y install --no-install-recommends \
-    git unzip
+    git unzip libpq-dev
     
-RUN docker-php-ext-install pdo_mysql
-
-
+RUN docker-php-ext-install pdo_mysql pgsql pdo_pgsql
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,14 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: yes
     ports:
       - '3306:3306'
+      
+  db:
+    image: postgres:9.2
+    environment:
+      POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --no-locale"
+    command: ["postgres", "-c", "log_statement=all"]
+    ports:
+      - "5432:5432"
 
   php:
     build:
@@ -15,6 +23,7 @@ services:
       dockerfile: Dockerfile.php8.3
     environment:
       - MYSQL_DB_HOST=mysql
+      - POSTGRES_DB_HOST=db
     volumes:
       - .:/usr/src/myapp
 
@@ -25,5 +34,6 @@ services:
       dockerfile: Dockerfile.php8.4
     environment:
       - MYSQL_DB_HOST=mysql
+      - POSTGRES_DB_HOST=db
     volumes:
       - .:/usr/src/myapp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,12 @@ services:
     volumes:
       - .:/usr/src/myapp
 
+
+  php84:
+    build:
+      context: .
+      dockerfile: Dockerfile.php8.4
+    environment:
+      - MYSQL_DB_HOST=mysql
+    volumes:
+      - .:/usr/src/myapp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,14 @@ services:
       MYSQL_DATABASE: dbunit
       MYSQL_ALLOW_EMPTY_PASSWORD: yes
     ports:
-      - '3406:3306'
+      - '3306:3306'
 
   php:
     build:
       context: .
       dockerfile: Dockerfile.php8.3
+    environment:
+      - MYSQL_DB_HOST=mysql
     volumes:
       - .:/usr/src/myapp
+

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,8 +16,8 @@
     </testsuites>
 
     <php>
-        <env name="MYSQL_DB_HOST" value="127.0.0.1"/>
-        <env name="MYSQL_DB_PORT" value="3406"/>
+        <!-- <env name="MYSQL_DB_HOST" value="127.0.0.1"/> -->
+        <env name="MYSQL_DB_PORT" value="3306"/>
         <env name="MYSQL_DB_NAME" value="dbunit"/>
         <env name="MYSQL_DB_USER" value="root"/>
         <env name="MYSQL_DB_PASSWORD" value=""/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,10 @@
             <directory>tests/Mysql/</directory>
             <exclude>tests/_files/*</exclude>
         </testsuite>
+        <testsuite name="pgsql">
+            <directory>tests/Pgsql/</directory>
+            <exclude>tests/_files/*</exclude>
+        </testsuite>
         <testsuite name="unit">
             <directory>tests/Unit/</directory>
             <exclude>tests/_files/*</exclude>
@@ -21,6 +25,11 @@
         <env name="MYSQL_DB_NAME" value="dbunit"/>
         <env name="MYSQL_DB_USER" value="root"/>
         <env name="MYSQL_DB_PASSWORD" value=""/>
+        
+        <!-- <env name="POSTGRES_DB_HOST" value="127.0.0.1"/> -->
+        <env name="POSTGRES_DB_PORT" value="5432"/>
+        <env name="POSTGRES_DB_NAME" value="postgres"/>
+        <env name="POSTGRES_DB_USER" value="postgres"/>
     </php>
 
     <source>

--- a/tests/Pgsql/OperationsPsqlTest.php
+++ b/tests/Pgsql/OperationsPsqlTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of DbUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PHPUnit\DbUnit\Tests\Psql\Operation;
+
+use DatabaseTestUtility;
+use PHPUnit\DbUnit\Database\DefaultConnection;
+use PHPUnit\DbUnit\DataSet\CompositeDataSet;
+use PHPUnit\DbUnit\DataSet\DefaultDataSet;
+use PHPUnit\DbUnit\DataSet\DefaultTable;
+use PHPUnit\DbUnit\DataSet\DefaultTableMetadata;
+use PHPUnit\DbUnit\DataSet\FlatXmlDataSet;
+use PHPUnit\DbUnit\Operation\Truncate;
+use PHPUnit\DbUnit\TestCase;
+
+class OperationsPsqlTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!\extension_loaded('pdo_pgsql')) {
+            $this->markTestSkipped('pdo_pgsql is required to run this test.');
+        }
+
+        if (getenv('POSTGRES_DB_HOST') === false) {
+            $this->markTestSkipped('No Postgresql server configured for this test.');
+        }
+
+        parent::setUp();
+    }
+
+    public function getConnection()
+    {
+        return new DefaultConnection(DatabaseTestUtility::getPostgreSQLDB(), 'postgres');
+    }
+
+    public function getDataSet()
+    {
+        return new FlatXmlDataSet(TEST_FILES_PATH . 'XmlDataSets/OperationsMySQLTestFixture.xml');
+    }
+
+    public function testTruncate(): void
+    {
+        $truncateOperation = new Truncate();
+        $truncateOperation->execute($this->getConnection(), $this->getDataSet());
+
+        $expectedDataSet = new DefaultDataSet([
+            new DefaultTable(
+                new DefaultTableMetadata(
+                    'table1',
+                    ['table1_id', 'column1', 'column2', 'column3', 'column4']
+                )
+            ),
+            new DefaultTable(
+                new DefaultTableMetadata(
+                    'table2',
+                    ['table2_id', 'table1_id', 'column5', 'column6', 'column7', 'column8']
+                )
+            ),
+            new DefaultTable(
+                new DefaultTableMetadata(
+                    'table3',
+                    ['table3_id', 'table2_id', 'column9', 'column10', 'column11', 'column12']
+                )
+            ),
+        ]);
+
+        self::assertDataSetsEqual($expectedDataSet, $this->getConnection()->createDataSet());
+    }
+
+    public function getCompositeDataSet(): CompositeDataSet
+    {
+        $compositeDataset = new CompositeDataSet();
+
+        $dataset = $this->createXMLDataSet(TEST_FILES_PATH . 'XmlDataSets/TruncateCompositeTest.xml');
+        $compositeDataset->addDataSet($dataset);
+
+        return $compositeDataset;
+    }
+
+    public function testTruncateComposite(): void
+    {
+        $truncateOperation = new Truncate();
+        $truncateOperation->execute($this->getConnection(), $this->getCompositeDataSet());
+
+        $expectedDataSet = new DefaultDataSet([
+            new DefaultTable(
+                new DefaultTableMetadata(
+                    'table1',
+                    ['table1_id', 'column1', 'column2', 'column3', 'column4']
+                )
+            ),
+            new DefaultTable(
+                new DefaultTableMetadata(
+                    'table2',
+                    ['table2_id', 'table1_id', 'column5', 'column6', 'column7', 'column8']
+                )
+            ),
+            new DefaultTable(
+                new DefaultTableMetadata(
+                    'table3',
+                    ['table3_id', 'table2_id', 'column9', 'column10', 'column11', 'column12']
+                )
+            ),
+        ]);
+
+        self::assertDataSetsEqual($expectedDataSet, $this->getConnection()->createDataSet());
+    }
+}

--- a/tests/Pgsql/OperationsPsqlTest.php
+++ b/tests/Pgsql/OperationsPsqlTest.php
@@ -38,7 +38,7 @@ class OperationsPsqlTest extends TestCase
 
     public function getConnection()
     {
-        return new DefaultConnection(DatabaseTestUtility::getPostgreSQLDB(), 'postgres');
+        return new DefaultConnection(DatabaseTestUtility::getPostgreSQLDB());
     }
 
     public function getDataSet()

--- a/tests/_files/DatabaseTestUtility.php
+++ b/tests/_files/DatabaseTestUtility.php
@@ -183,6 +183,7 @@ class DatabaseTestUtility
         $connection->exec(
             'CREATE TABLE table2 (
             table2_id SERIAL PRIMARY KEY,
+            table1_id INTEGER,
             column5 VARCHAR(20),
             column6 INT,
             column7 DECIMAL(6,2),
@@ -194,6 +195,7 @@ class DatabaseTestUtility
         $connection->exec(
             'CREATE TABLE table3 (
             table3_id SERIAL PRIMARY KEY,
+            table2_id INTEGER,
             column9 VARCHAR(20),
             column10 INT,
             column11 DECIMAL(6,2),

--- a/tests/_files/DatabaseTestUtility.php
+++ b/tests/_files/DatabaseTestUtility.php
@@ -15,6 +15,8 @@ class DatabaseTestUtility
 
     protected static $mySQLConnection;
 
+    protected static $postgreSQLConnection;
+
     public static function getSQLiteMemoryDB()
     {
         if (self::$connection === null) {
@@ -48,6 +50,29 @@ class DatabaseTestUtility
         }
 
         return self::$mySQLConnection;
+    }
+
+    /**
+     * Creates connection to test PostgreSQL database
+     *
+     * PostgreSQL server must be installed locally, with appropriate access
+     * credentials set in environment variables
+     *
+     * @return PDO
+     */
+    public static function getPostgreSQLDB()
+    {
+        if (self::$postgreSQLConnection === null) {
+            self::$postgreSQLConnection = new PDO(
+                self::buildPostgreSQLDSN(),
+                getenv('POSTGRESL_DB_USER'),
+                getenv('POSTGRESL_DB_PASSWORD')
+            );
+
+            self::setUpPostgreSQLDatabase(self::$postgreSQLConnection);
+        }
+
+        return self::$postgreSQLConnection;
     }
 
     protected static function setUpDatabase(PDO $connection): void
@@ -138,6 +163,41 @@ class DatabaseTestUtility
         );
     }
 
+    protected static function setUpPostgreSQLDatabase(PDO $connection): void
+    {
+        $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $connection->exec(
+            'CREATE TABLE IF NOT EXISTS table1 (
+            table1_id SERIAL PRIMARY KEY,
+            column1 VARCHAR(20),
+            column2 INT,
+            column3 DECIMAL(6,2),
+            column4 TEXT
+          )'
+        );
+
+        $connection->exec(
+            'CREATE TABLE IF NOT EXISTS table2 (
+            table2_id SERIAL PRIMARY KEY,
+            column5 VARCHAR(20),
+            column6 INT,
+            column7 DECIMAL(6,2),
+            column8 TEXT
+          )'
+        );
+
+        $connection->exec(
+            'CREATE TABLE IF NOT EXISTS table3 (
+            table3_id SERIAL PRIMARY KEY,
+            column9 VARCHAR(20),
+            column10 INT,
+            column11 DECIMAL(6,2),
+            column12 TEXT
+          )'
+        );
+    }
+
     private static function buildMysqlDSN(): string
     {
         return sprintf(
@@ -145,6 +205,16 @@ class DatabaseTestUtility
             getenv('MYSQL_DB_HOST'),
             getenv('MYSQL_DB_NAME'),
             getenv('MYSQL_DB_PORT')
+        );
+    }
+
+    private static function buildPostgreSQLDSN(): string
+    {
+        return sprintf(
+            'pgsql:host=%s;dbname=%s;port=%s',
+            getenv('POSTGRESL_DB_HOST'),
+            getenv('POSTGRESL_DB_NAME'),
+            getenv('POSTGRESL_DB_PORT')
         );
     }
 }

--- a/tests/_files/DatabaseTestUtility.php
+++ b/tests/_files/DatabaseTestUtility.php
@@ -65,8 +65,8 @@ class DatabaseTestUtility
         if (self::$postgreSQLConnection === null) {
             self::$postgreSQLConnection = new PDO(
                 self::buildPostgreSQLDSN(),
-                getenv('POSTGRESL_DB_USER'),
-                getenv('POSTGRESL_DB_PASSWORD')
+                getenv('POSTGRES_DB_USER'),
+                getenv('POSTGRES_DB_PASSWORD')
             );
 
             self::setUpPostgreSQLDatabase(self::$postgreSQLConnection);
@@ -167,18 +167,21 @@ class DatabaseTestUtility
     {
         $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
+        $connection->exec('DROP TABLE table1');
         $connection->exec(
-            'CREATE TABLE IF NOT EXISTS table1 (
+            'CREATE TABLE table1 (
             table1_id SERIAL PRIMARY KEY,
             column1 VARCHAR(20),
             column2 INT,
             column3 DECIMAL(6,2),
             column4 TEXT
-          )'
+          )
+          '
         );
 
+        $connection->exec('DROP TABLE table2');
         $connection->exec(
-            'CREATE TABLE IF NOT EXISTS table2 (
+            'CREATE TABLE table2 (
             table2_id SERIAL PRIMARY KEY,
             column5 VARCHAR(20),
             column6 INT,
@@ -187,8 +190,9 @@ class DatabaseTestUtility
           )'
         );
 
+        $connection->exec('DROP TABLE table3');
         $connection->exec(
-            'CREATE TABLE IF NOT EXISTS table3 (
+            'CREATE TABLE table3 (
             table3_id SERIAL PRIMARY KEY,
             column9 VARCHAR(20),
             column10 INT,
@@ -212,9 +216,9 @@ class DatabaseTestUtility
     {
         return sprintf(
             'pgsql:host=%s;dbname=%s;port=%s',
-            getenv('POSTGRESL_DB_HOST'),
-            getenv('POSTGRESL_DB_NAME'),
-            getenv('POSTGRESL_DB_PORT')
+            getenv('POSTGRES_DB_HOST'),
+            getenv('POSTGRES_DB_NAME'),
+            getenv('POSTGRES_DB_PORT')
         );
     }
 }

--- a/tests/_files/DatabaseTestUtility.php
+++ b/tests/_files/DatabaseTestUtility.php
@@ -167,7 +167,7 @@ class DatabaseTestUtility
     {
         $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-        $connection->exec('DROP TABLE table1');
+        $connection->exec('DROP TABLE if exists table1');
         $connection->exec(
             'CREATE TABLE table1 (
             table1_id SERIAL PRIMARY KEY,
@@ -179,7 +179,7 @@ class DatabaseTestUtility
           '
         );
 
-        $connection->exec('DROP TABLE table2');
+        $connection->exec('DROP TABLE if exists table2');
         $connection->exec(
             'CREATE TABLE table2 (
             table2_id SERIAL PRIMARY KEY,
@@ -191,7 +191,7 @@ class DatabaseTestUtility
           )'
         );
 
-        $connection->exec('DROP TABLE table3');
+        $connection->exec('DROP TABLE if exists table3');
         $connection->exec(
             'CREATE TABLE table3 (
             table3_id SERIAL PRIMARY KEY,


### PR DESCRIPTION
This pull request includes extensive changes to add PostgreSQL support alongside the existing MySQL setup. The changes span multiple files, including workflow configurations, Docker setup, PHPUnit configurations, and test utilities.

### Workflow and Docker Configuration Updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R37): Added environment variables for MySQL and updated port mappings for MySQL service. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R37) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L46-R47) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R67-R69) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R86-R91)
* [`.github/workflows/pg.yml`](diffhunk://#diff-5d5acba9ff88efb21a24d90f3edeb1b03072ee57dd1a89e235a8be9a062a98f0R1-R54): Introduced a new workflow configuration for PostgreSQL testing, including service setup and environment variables.
* [`Dockerfile.php8.3`](diffhunk://#diff-437b168e075cf2e9d8284bdcaf945b5af234c8c485df5d75aaac493876d6a83bL5-R7): Added PostgreSQL dependencies and extensions.
* [`Dockerfile.php8.4`](diffhunk://#diff-459f2677fc73d179183d88fed2660ab49fe4e5ce0de4819a20b09d5eed72d8cbR1-R11): Created a new Dockerfile for PHP 8.4 with PostgreSQL dependencies and extensions.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L10-R37): Updated MySQL port mappings and added PostgreSQL service configuration.

### PHPUnit Configuration:

* [`phpunit.xml.dist`](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892R12-R32): Added a new test suite for PostgreSQL and updated environment variables for database hosts and ports.

### Test Enhancements:

* [`tests/Pgsql/OperationsPsqlTest.php`](diffhunk://#diff-62ef8eb92a6553f9a50017c9fc68b1a2d37594772581ea93941063e228ad62a8R1-R116): Added new test cases for PostgreSQL operations.
* [`tests/_files/DatabaseTestUtility.php`](diffhunk://#diff-7357d4fb8390dfad808265970cdc1d7b699723bceb476dcfb392a26d608ed6eeR18-R19): Introduced methods for PostgreSQL database connection and setup, mirroring the existing MySQL setup. [[1]](diffhunk://#diff-7357d4fb8390dfad808265970cdc1d7b699723bceb476dcfb392a26d608ed6eeR18-R19) [[2]](diffhunk://#diff-7357d4fb8390dfad808265970cdc1d7b699723bceb476dcfb392a26d608ed6eeR55-R77) [[3]](diffhunk://#diff-7357d4fb8390dfad808265970cdc1d7b699723bceb476dcfb392a26d608ed6eeR166-R206) [[4]](diffhunk://#diff-7357d4fb8390dfad808265970cdc1d7b699723bceb476dcfb392a26d608ed6eeR216-R225)